### PR TITLE
fix(analytics): resolve timestamp display issues in ClickHouse views …

### DIFF
--- a/data-platform/dashboards/grafana/customer-insights.json
+++ b/data-platform/dashboards/grafana/customer-insights.json
@@ -22,7 +22,7 @@
         },
         "targets": [
           {
-            "rawSql": "SELECT 'Total Customers' as metric, count(*) as value FROM ecommerce_analytics.customers_cdc WHERE _deleted = 0 UNION ALL SELECT 'Active Customers (with orders)', count(DISTINCT customer_id) FROM ecommerce_analytics.orders_cdc WHERE _deleted = 0 UNION ALL SELECT 'New Customers (Last 7d)', count(*) FROM ecommerce_analytics.customers_cdc WHERE _deleted = 0 AND fromUnixTimestamp64Milli(created_at) >= now() - INTERVAL 7 DAY",
+            "rawSql": "SELECT 'Total Customers' as metric, count(*) as value FROM ecommerce_analytics.customers_cdc WHERE _deleted = 0 UNION ALL SELECT 'Active Customers (with orders)', count(DISTINCT customer_id) FROM ecommerce_analytics.orders_cdc WHERE _deleted = 0 UNION ALL SELECT 'New Customers (Last 7d)', count(*) FROM ecommerce_analytics.customers_cdc WHERE _deleted = 0 AND fromUnixTimestamp64Micro(created_at) >= now() - INTERVAL 7 DAY",
             "format": 1,
             "queryType": "sql",
             "datasource": {
@@ -91,7 +91,7 @@
         },
         "targets": [
           {
-            "rawSql": "SELECT toDate(fromUnixTimestamp64Milli(created_at)) as date, count(*) as new_customers FROM ecommerce_analytics.customers_cdc WHERE _deleted = 0 AND created_at >= toUnixTimestamp64Milli(now() - INTERVAL 30 DAY) GROUP BY date ORDER BY date",
+            "rawSql": "SELECT toDate(fromUnixTimestamp64Micro(created_at)) as date, count(*) as new_customers FROM ecommerce_analytics.customers_cdc WHERE _deleted = 0 AND fromUnixTimestamp64Micro(created_at) >= now() - INTERVAL 30 DAY GROUP BY date ORDER BY date",
             "format": 1,
             "queryType": "sql",
             "datasource": {

--- a/data-platform/dashboards/grafana/executive-dashboard.json
+++ b/data-platform/dashboards/grafana/executive-dashboard.json
@@ -22,7 +22,7 @@
         },
         "targets": [
           {
-            "rawSql": "SELECT activity_type, count_24h FROM ecommerce_analytics.recent_activity",
+            "rawSql": "SELECT activity_type, total_records FROM ecommerce_analytics.recent_activity",
             "format": 1,
             "queryType": "sql",
             "datasource": {
@@ -91,7 +91,7 @@
         },
         "targets": [
           {
-            "rawSql": "SELECT hour, order_count FROM ecommerce_analytics.hourly_orders_trend ORDER BY hour",
+            "rawSql": "SELECT CONCAT(toString(hour), ':00') as hour_label, order_count FROM ecommerce_analytics.hourly_orders_trend ORDER BY hour",
             "format": 1,
             "queryType": "sql",
             "datasource": {

--- a/data-platform/dashboards/grafana/test-dashboard.json
+++ b/data-platform/dashboards/grafana/test-dashboard.json
@@ -22,7 +22,7 @@
       },
       "targets": [
         {
-          "rawSql": "SELECT activity_type, count_24h, last_activity FROM ecommerce_analytics.recent_activity",
+          "rawSql": "SELECT activity_type, total_records, last_activity FROM ecommerce_analytics.recent_activity",
           "format": 1,
           "queryType": "sql",
           "datasource": {

--- a/infrastructure/docker/grafana/provisioning/dashboards/files/customer-insights.json
+++ b/infrastructure/docker/grafana/provisioning/dashboards/files/customer-insights.json
@@ -22,7 +22,7 @@
         },
         "targets": [
           {
-            "rawSql": "SELECT 'Total Customers' as metric, count(*) as value FROM ecommerce_analytics.customers_cdc WHERE _deleted = 0 UNION ALL SELECT 'Active Customers (with orders)', count(DISTINCT customer_id) FROM ecommerce_analytics.orders_cdc WHERE _deleted = 0 UNION ALL SELECT 'New Customers (Last 7d)', count(*) FROM ecommerce_analytics.customers_cdc WHERE _deleted = 0 AND fromUnixTimestamp64Milli(created_at) >= now() - INTERVAL 7 DAY",
+            "rawSql": "SELECT 'Total Customers' as metric, count(*) as value FROM ecommerce_analytics.customers_cdc WHERE _deleted = 0 UNION ALL SELECT 'Active Customers (with orders)', count(DISTINCT customer_id) FROM ecommerce_analytics.orders_cdc WHERE _deleted = 0 UNION ALL SELECT 'New Customers (Last 7d)', count(*) FROM ecommerce_analytics.customers_cdc WHERE _deleted = 0 AND fromUnixTimestamp64Micro(created_at) >= now() - INTERVAL 7 DAY",
             "format": 1,
             "queryType": "sql",
             "datasource": {
@@ -91,7 +91,7 @@
         },
         "targets": [
           {
-            "rawSql": "SELECT toDate(fromUnixTimestamp64Milli(created_at)) as date, count(*) as new_customers FROM ecommerce_analytics.customers_cdc WHERE _deleted = 0 AND created_at >= toUnixTimestamp64Milli(now() - INTERVAL 30 DAY) GROUP BY date ORDER BY date",
+            "rawSql": "SELECT toDate(fromUnixTimestamp64Micro(created_at)) as date, count(*) as new_customers FROM ecommerce_analytics.customers_cdc WHERE _deleted = 0 AND fromUnixTimestamp64Micro(created_at) >= now() - INTERVAL 30 DAY GROUP BY date ORDER BY date",
             "format": 1,
             "queryType": "sql",
             "datasource": {

--- a/infrastructure/docker/grafana/provisioning/dashboards/files/executive-dashboard.json
+++ b/infrastructure/docker/grafana/provisioning/dashboards/files/executive-dashboard.json
@@ -22,7 +22,7 @@
         },
         "targets": [
           {
-            "rawSql": "SELECT activity_type, count_24h FROM ecommerce_analytics.recent_activity",
+            "rawSql": "SELECT activity_type, total_records FROM ecommerce_analytics.recent_activity",
             "format": 1,
             "queryType": "sql",
             "datasource": {
@@ -91,7 +91,7 @@
         },
         "targets": [
           {
-            "rawSql": "SELECT hour, order_count FROM ecommerce_analytics.hourly_orders_trend ORDER BY hour",
+            "rawSql": "SELECT CONCAT(toString(hour), ':00') as hour_label, order_count FROM ecommerce_analytics.hourly_orders_trend ORDER BY hour",
             "format": 1,
             "queryType": "sql",
             "datasource": {

--- a/infrastructure/docker/grafana/provisioning/dashboards/files/test-dashboard.json
+++ b/infrastructure/docker/grafana/provisioning/dashboards/files/test-dashboard.json
@@ -22,7 +22,7 @@
       },
       "targets": [
         {
-          "rawSql": "SELECT activity_type, count_24h, last_activity FROM ecommerce_analytics.recent_activity",
+          "rawSql": "SELECT activity_type, total_records, last_activity FROM ecommerce_analytics.recent_activity",
           "format": 1,
           "queryType": "sql",
           "datasource": {


### PR DESCRIPTION
…and Grafana dashboards

- Fix ClickHouse analytics views to use correct timestamp functions:
  * fromUnixTimestamp64Micro for data fields (order_time, created_at)
  * fromUnixTimestamp64Milli for CDC _version fields
- Update all Grafana dashboard queries to match corrected timestamp format
- Fix bar chart visualization requiring string fields with CONCAT formatting
- Update dashboard field names for consistency (count_24h → total_records)
- Remove unnecessary update script

Resolves timestamp errors showing years 1970/2061/2299 in dashboards All analytics views now display correct 2025 timestamps